### PR TITLE
Fix multiple meta mask watchers

### DIFF
--- a/src/components/Account.js
+++ b/src/components/Account.js
@@ -82,8 +82,12 @@ export class Account extends Component {
         console.log("Initializing timers")
         this.watchNetwork();
         this.watchWallet();
-        this.watchNetworkTimer = setInterval(() => this.watchNetwork(), 500);
-        this.watchWalletTimer = setInterval(() => this.watchWallet(), 500);
+        if (!this.watchNetworkTimer) {
+          this.watchNetworkTimer = setInterval(() => this.watchNetwork(), 500);
+        }
+        if (!this.watchWalletTimer) {
+          this.watchWalletTimer = setInterval(() => this.watchWallet(), 500);
+        }
       }
     }).catch(err => {
       console.error(err);

--- a/src/components/Services.js
+++ b/src/components/Services.js
@@ -128,8 +128,10 @@ class SampleServices extends React.Component {
       if (isInitialized) {
         console.log("Initializing the watchNetwork timer");
         this.watchNetwork();
-        this.watchNetworkTimer = setInterval(() => this.watchNetwork(), 500);
-      } 
+        if (!this.watchNetworkTimer) {
+          this.watchNetworkTimer = setInterval(() => this.watchNetwork(), 500);
+        }
+      }
       else {
         this.setState({chainId: this.network.getDefaultNetwork()});
         console.log("Defaulting to " + this.state.chainId);


### PR DESCRIPTION
Since we override the existing watcher without clearing it from the interval,
registering another watcher would override the currently registered watcher without
clearing it from the interval. This will leave a watcher which never gets cleared.