### PR TITLE
Removed SMPDB from gene pathway filter

### DIFF
--- a/src/components/service/gene-annotation-service/GenePathwayFilter.js
+++ b/src/components/service/gene-annotation-service/GenePathwayFilter.js
@@ -8,7 +8,6 @@ import {
 } from "@material-ui/core";
 
 const options = [
-  { label: "SMPDB", value: "smpdb" },
   { label: "Reactome", value: "reactome" }
 ];
 


### PR DESCRIPTION
This PR contains a small fix that removes the SMPDB(small molecules pathway database) option as it will not be part of the service due to licensing issue.