### PR TITLE
Removed entrez id and smpdb from default options

### DIFF
--- a/src/components/service/GeneAnnotationService.js
+++ b/src/components/service/GeneAnnotationService.js
@@ -59,7 +59,6 @@ const availableAnnotations = [
         "cellular_component",
         "molecular_function"
       ],
-      get_entrez_id: "False",
       parents: 0
     },
     fitlerForm: (defaults, handleFilterChanged) => (
@@ -70,7 +69,7 @@ const availableAnnotations = [
     key: "gene_pathway_annotation",
     name: "Gene pathway",
     defaults: {
-      namespace: ["smpdb"],
+      namespace: [],
       include_prot: false,
       include_small_molecule: true
     },


### PR DESCRIPTION
This PR removes default options that are no longer supported by the `gene-annotation-service`. Namely, we are removing `entrez_id` and `smpdb` default options.