### PR TITLE
Hover Icon component

### DIFF
--- a/src/components/service/Places365SceneRecognition.js
+++ b/src/components/service/Places365SceneRecognition.js
@@ -15,6 +15,7 @@ import TableHead from "@material-ui/core/TableHead";
 import Table from "@material-ui/core/Table";
 import TableRow from "@material-ui/core/TableRow";
 import TableBody from "@material-ui/core/TableBody";
+import HoverIcon from "./standardComponents/HoverIcon";
 
 export default class Places365SceneRecognition extends React.Component {
 
@@ -49,7 +50,7 @@ export default class Places365SceneRecognition extends React.Component {
         };
 
         this.users_guide = "https://singnet.github.io/dnn-model-services/users_guide/places365-scene-recognition.html";
-        this.code_repo = "https://github.com/singnet/dnn-model-services/tree/master/Services/gRPC/places365-scene-recognition";
+        this.code_repo = "https://github.com/singnet/dnn-model-services/tree/master/services/places365-scene-recognition";
         this.reference = "https://github.com/CSAILVision/places365";
 
         this.submitAction = this.submitAction.bind(this);
@@ -230,90 +231,25 @@ export default class Places365SceneRecognition extends React.Component {
                                 </Grid>
                                 <Grid item xs container justify="flex-end">
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    View code on Github
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({githubIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({githubIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.githubIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.code_repo}
-                                            >
-                                                <SvgIcon>
-                                                    <path // Github Icon
-                                                        d="M12.007 0C6.12 0 1.1 4.27.157 10.08c-.944 5.813 2.468 11.45 8.054 13.312.19.064.397.033.555-.084.16-.117.25-.304.244-.5v-2.042c-3.33.735-4.037-1.56-4.037-1.56-.22-.726-.694-1.35-1.334-1.756-1.096-.75.074-.735.074-.735.773.103 1.454.557 1.846 1.23.694 1.21 2.23 1.638 3.45.96.056-.61.327-1.178.766-1.605-2.67-.3-5.462-1.335-5.462-6.002-.02-1.193.42-2.35 1.23-3.226-.327-1.015-.27-2.116.166-3.09 0 0 1.006-.33 3.3 1.23 1.966-.538 4.04-.538 6.003 0 2.295-1.5 3.3-1.23 3.3-1.23.445 1.006.49 2.144.12 3.18.81.877 1.25 2.033 1.23 3.226 0 4.607-2.805 5.627-5.476 5.927.578.583.88 1.386.825 2.206v3.29c-.005.2.092.393.26.507.164.115.377.14.565.063 5.568-1.88 8.956-7.514 8.007-13.313C22.892 4.267 17.884.007 12.008 0z"/>
-                                                </SvgIcon>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="View code on Github" href={this.code_repo}>
+                                            <SvgIcon>
+                                                <path // Github Icon
+                                                    d="M12.007 0C6.12 0 1.1 4.27.157 10.08c-.944 5.813 2.468 11.45 8.054 13.312.19.064.397.033.555-.084.16-.117.25-.304.244-.5v-2.042c-3.33.735-4.037-1.56-4.037-1.56-.22-.726-.694-1.35-1.334-1.756-1.096-.75.074-.735.074-.735.773.103 1.454.557 1.846 1.23.694 1.21 2.23 1.638 3.45.96.056-.61.327-1.178.766-1.605-2.67-.3-5.462-1.335-5.462-6.002-.02-1.193.42-2.35 1.23-3.226-.327-1.015-.27-2.116.166-3.09 0 0 1.006-.33 3.3 1.23 1.966-.538 4.04-.538 6.003 0 2.295-1.5 3.3-1.23 3.3-1.23.445 1.006.49 2.144.12 3.18.81.877 1.25 2.033 1.23 3.226 0 4.607-2.805 5.627-5.476 5.927.578.583.88 1.386.825 2.206v3.29c-.005.2.092.393.26.507.164.115.377.14.565.063 5.568-1.88 8.956-7.514 8.007-13.313C22.892 4.267 17.884.007 12.008 0z"/>
+                                            </SvgIcon>
+                                        </HoverIcon>
                                     </Grid>
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    User's guide
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({infoIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({infoIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.infoIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.users_guide}
-                                            >
-                                                <InfoIcon/>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="User's guide" href={this.users_guide}>
+                                            <InfoIcon/>
+                                        </HoverIcon>
                                     </Grid>
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    View original project
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({referenceIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({referenceIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.referenceIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.reference}>
-                                                <SvgIcon>
-                                                    <path
-                                                        d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm0 11.701c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701zm6 0c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701z"/>
-                                                </SvgIcon>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="View original project" href={this.reference}>
+                                            <SvgIcon>
+                                                <path
+                                                    d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm0 11.701c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701zm6 0c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701z"/>
+                                            </SvgIcon>
+                                        </HoverIcon>
                                     </Grid>
                                 </Grid>
                             </Grid>

--- a/src/components/service/SemanticSegmentationAerial.js
+++ b/src/components/service/SemanticSegmentationAerial.js
@@ -17,6 +17,7 @@ import MenuItem from "@material-ui/core/MenuItem";
 import TextField from "@material-ui/core/TextField";
 import ReactDOM from "react-dom";
 import SNETImageUpload from "./standardComponents/SNETImageUpload";
+import HoverIcon from "./standardComponents/HoverIcon";
 
 export default class SemanticSegmentationAerial extends React.Component {
 
@@ -297,90 +298,25 @@ export default class SemanticSegmentationAerial extends React.Component {
                             <Grid item xs={12} container alignItems="center" justify="flex-end">
                                 <Grid item xs container justify="flex-end">
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    View code on Github
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({githubIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({githubIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.githubIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.code_repo}
-                                            >
-                                                <SvgIcon>
-                                                    <path // Github Icon
-                                                        d="M12.007 0C6.12 0 1.1 4.27.157 10.08c-.944 5.813 2.468 11.45 8.054 13.312.19.064.397.033.555-.084.16-.117.25-.304.244-.5v-2.042c-3.33.735-4.037-1.56-4.037-1.56-.22-.726-.694-1.35-1.334-1.756-1.096-.75.074-.735.074-.735.773.103 1.454.557 1.846 1.23.694 1.21 2.23 1.638 3.45.96.056-.61.327-1.178.766-1.605-2.67-.3-5.462-1.335-5.462-6.002-.02-1.193.42-2.35 1.23-3.226-.327-1.015-.27-2.116.166-3.09 0 0 1.006-.33 3.3 1.23 1.966-.538 4.04-.538 6.003 0 2.295-1.5 3.3-1.23 3.3-1.23.445 1.006.49 2.144.12 3.18.81.877 1.25 2.033 1.23 3.226 0 4.607-2.805 5.627-5.476 5.927.578.583.88 1.386.825 2.206v3.29c-.005.2.092.393.26.507.164.115.377.14.565.063 5.568-1.88 8.956-7.514 8.007-13.313C22.892 4.267 17.884.007 12.008 0z"/>
-                                                </SvgIcon>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="View code on Github" href={this.code_repo}>
+                                            <SvgIcon>
+                                                <path // Github Icon
+                                                    d="M12.007 0C6.12 0 1.1 4.27.157 10.08c-.944 5.813 2.468 11.45 8.054 13.312.19.064.397.033.555-.084.16-.117.25-.304.244-.5v-2.042c-3.33.735-4.037-1.56-4.037-1.56-.22-.726-.694-1.35-1.334-1.756-1.096-.75.074-.735.074-.735.773.103 1.454.557 1.846 1.23.694 1.21 2.23 1.638 3.45.96.056-.61.327-1.178.766-1.605-2.67-.3-5.462-1.335-5.462-6.002-.02-1.193.42-2.35 1.23-3.226-.327-1.015-.27-2.116.166-3.09 0 0 1.006-.33 3.3 1.23 1.966-.538 4.04-.538 6.003 0 2.295-1.5 3.3-1.23 3.3-1.23.445 1.006.49 2.144.12 3.18.81.877 1.25 2.033 1.23 3.226 0 4.607-2.805 5.627-5.476 5.927.578.583.88 1.386.825 2.206v3.29c-.005.2.092.393.26.507.164.115.377.14.565.063 5.568-1.88 8.956-7.514 8.007-13.313C22.892 4.267 17.884.007 12.008 0z"/>
+                                            </SvgIcon>
+                                        </HoverIcon>
                                     </Grid>
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    User's guide
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({infoIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({infoIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.infoIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.users_guide}
-                                            >
-                                                <InfoIcon/>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="User's guide" href={this.users_guide}>
+                                            <InfoIcon/>
+                                        </HoverIcon>
                                     </Grid>
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    View original project
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({referenceIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({referenceIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.referenceIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.reference}>
-                                                <SvgIcon>
-                                                    <path
-                                                        d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm0 11.701c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701zm6 0c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701z"/>
-                                                </SvgIcon>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="View original project" href={this.reference}>
+                                            <SvgIcon>
+                                                <path
+                                                    d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm0 11.701c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701zm6 0c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701z"/>
+                                            </SvgIcon>
+                                        </HoverIcon>
                                     </Grid>
                                 </Grid>
                             </Grid>

--- a/src/components/service/StyleTransfer.js
+++ b/src/components/service/StyleTransfer.js
@@ -12,6 +12,7 @@ import grey from "@material-ui/core/es/colors/grey";
 import red from "@material-ui/core/es/colors/red";
 import Switch from "@material-ui/core/Switch";
 import Slider from "@material-ui/lab/Slider";
+import HoverIcon from "./standardComponents/HoverIcon"
 
 export default class StyleTransfer extends React.Component {
 
@@ -281,90 +282,25 @@ export default class StyleTransfer extends React.Component {
                                 </Grid>
                                 <Grid item xs container justify="flex-end">
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    View code on Github
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({githubIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({githubIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.githubIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.code_repo}
-                                            >
-                                                <SvgIcon>
-                                                    <path // Github Icon
-                                                        d="M12.007 0C6.12 0 1.1 4.27.157 10.08c-.944 5.813 2.468 11.45 8.054 13.312.19.064.397.033.555-.084.16-.117.25-.304.244-.5v-2.042c-3.33.735-4.037-1.56-4.037-1.56-.22-.726-.694-1.35-1.334-1.756-1.096-.75.074-.735.074-.735.773.103 1.454.557 1.846 1.23.694 1.21 2.23 1.638 3.45.96.056-.61.327-1.178.766-1.605-2.67-.3-5.462-1.335-5.462-6.002-.02-1.193.42-2.35 1.23-3.226-.327-1.015-.27-2.116.166-3.09 0 0 1.006-.33 3.3 1.23 1.966-.538 4.04-.538 6.003 0 2.295-1.5 3.3-1.23 3.3-1.23.445 1.006.49 2.144.12 3.18.81.877 1.25 2.033 1.23 3.226 0 4.607-2.805 5.627-5.476 5.927.578.583.88 1.386.825 2.206v3.29c-.005.2.092.393.26.507.164.115.377.14.565.063 5.568-1.88 8.956-7.514 8.007-13.313C22.892 4.267 17.884.007 12.008 0z"/>
-                                                </SvgIcon>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="View code on Github" href={this.code_repo}>
+                                            <SvgIcon>
+                                                <path // Github Icon
+                                                    d="M12.007 0C6.12 0 1.1 4.27.157 10.08c-.944 5.813 2.468 11.45 8.054 13.312.19.064.397.033.555-.084.16-.117.25-.304.244-.5v-2.042c-3.33.735-4.037-1.56-4.037-1.56-.22-.726-.694-1.35-1.334-1.756-1.096-.75.074-.735.074-.735.773.103 1.454.557 1.846 1.23.694 1.21 2.23 1.638 3.45.96.056-.61.327-1.178.766-1.605-2.67-.3-5.462-1.335-5.462-6.002-.02-1.193.42-2.35 1.23-3.226-.327-1.015-.27-2.116.166-3.09 0 0 1.006-.33 3.3 1.23 1.966-.538 4.04-.538 6.003 0 2.295-1.5 3.3-1.23 3.3-1.23.445 1.006.49 2.144.12 3.18.81.877 1.25 2.033 1.23 3.226 0 4.607-2.805 5.627-5.476 5.927.578.583.88 1.386.825 2.206v3.29c-.005.2.092.393.26.507.164.115.377.14.565.063 5.568-1.88 8.956-7.514 8.007-13.313C22.892 4.267 17.884.007 12.008 0z"/>
+                                            </SvgIcon>
+                                        </HoverIcon>
                                     </Grid>
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    User's guide
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({infoIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({infoIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.infoIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.users_guide}
-                                            >
-                                                <InfoIcon/>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="User's guide" href={this.users_guide}>
+                                            <InfoIcon/>
+                                        </HoverIcon>
                                     </Grid>
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    View original project
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({referenceIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({referenceIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.referenceIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.reference}>
-                                                <SvgIcon>
-                                                    <path
-                                                        d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm0 11.701c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701zm6 0c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701z"/>
-                                                </SvgIcon>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="View original project" href={this.reference}>
+                                            <SvgIcon>
+                                                <path
+                                                    d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm0 11.701c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701zm6 0c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701z"/>
+                                            </SvgIcon>
+                                        </HoverIcon>
                                     </Grid>
                                 </Grid>
                             </Grid>

--- a/src/components/service/SuperResolution.js
+++ b/src/components/service/SuperResolution.js
@@ -16,6 +16,7 @@ import Select from "@material-ui/core/Select";
 import ReactDOM from 'react-dom';
 import InputLabel from "@material-ui/core/InputLabel";
 import FormControl from "@material-ui/core/FormControl";
+import HoverIcon from "./standardComponents/HoverIcon";
 
 export default class SuperResolution extends React.Component {
 
@@ -271,90 +272,25 @@ export default class SuperResolution extends React.Component {
                                 </Grid>
                                 <Grid item xs container justify="flex-end">
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    View code on Github
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({githubIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({githubIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.githubIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.code_repo}
-                                            >
-                                                <SvgIcon>
-                                                    <path // Github Icon
-                                                        d="M12.007 0C6.12 0 1.1 4.27.157 10.08c-.944 5.813 2.468 11.45 8.054 13.312.19.064.397.033.555-.084.16-.117.25-.304.244-.5v-2.042c-3.33.735-4.037-1.56-4.037-1.56-.22-.726-.694-1.35-1.334-1.756-1.096-.75.074-.735.074-.735.773.103 1.454.557 1.846 1.23.694 1.21 2.23 1.638 3.45.96.056-.61.327-1.178.766-1.605-2.67-.3-5.462-1.335-5.462-6.002-.02-1.193.42-2.35 1.23-3.226-.327-1.015-.27-2.116.166-3.09 0 0 1.006-.33 3.3 1.23 1.966-.538 4.04-.538 6.003 0 2.295-1.5 3.3-1.23 3.3-1.23.445 1.006.49 2.144.12 3.18.81.877 1.25 2.033 1.23 3.226 0 4.607-2.805 5.627-5.476 5.927.578.583.88 1.386.825 2.206v3.29c-.005.2.092.393.26.507.164.115.377.14.565.063 5.568-1.88 8.956-7.514 8.007-13.313C22.892 4.267 17.884.007 12.008 0z"/>
-                                                </SvgIcon>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="View code on Github" href={this.code_repo}>
+                                            <SvgIcon>
+                                                <path // Github Icon
+                                                    d="M12.007 0C6.12 0 1.1 4.27.157 10.08c-.944 5.813 2.468 11.45 8.054 13.312.19.064.397.033.555-.084.16-.117.25-.304.244-.5v-2.042c-3.33.735-4.037-1.56-4.037-1.56-.22-.726-.694-1.35-1.334-1.756-1.096-.75.074-.735.074-.735.773.103 1.454.557 1.846 1.23.694 1.21 2.23 1.638 3.45.96.056-.61.327-1.178.766-1.605-2.67-.3-5.462-1.335-5.462-6.002-.02-1.193.42-2.35 1.23-3.226-.327-1.015-.27-2.116.166-3.09 0 0 1.006-.33 3.3 1.23 1.966-.538 4.04-.538 6.003 0 2.295-1.5 3.3-1.23 3.3-1.23.445 1.006.49 2.144.12 3.18.81.877 1.25 2.033 1.23 3.226 0 4.607-2.805 5.627-5.476 5.927.578.583.88 1.386.825 2.206v3.29c-.005.2.092.393.26.507.164.115.377.14.565.063 5.568-1.88 8.956-7.514 8.007-13.313C22.892 4.267 17.884.007 12.008 0z"/>
+                                            </SvgIcon>
+                                        </HoverIcon>
                                     </Grid>
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    User's guide
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({infoIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({infoIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.infoIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.users_guide}
-                                            >
-                                                <InfoIcon/>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="User's guide" href={this.users_guide}>
+                                            <InfoIcon/>
+                                        </HoverIcon>
                                     </Grid>
                                     <Grid item>
-                                        <Tooltip
-                                            title={
-                                                <Typography
-                                                    style={{
-                                                        fontFamily: this.mainFont,
-                                                        fontSize: this.mainFontSize,
-                                                        color: "white"
-                                                    }}>
-                                                    View original project
-                                                </Typography>
-                                            }>
-                                            <IconButton
-                                                onMouseEnter={function () {
-                                                    this.setState({referenceIconHover: true})
-                                                }.bind(this)}
-                                                onMouseLeave={function () {
-                                                    this.setState({referenceIconHover: false})
-                                                }.bind(this)}
-                                                style={this.state.referenceIconHover ? {color: blue[500]} : {color: "grey"}}
-                                                target="_blank"
-                                                href={this.reference}>
-                                                <SvgIcon>
-                                                    <path
-                                                        d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm0 11.701c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701zm6 0c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701z"/>
-                                                </SvgIcon>
-                                            </IconButton>
-                                        </Tooltip>
+                                        <HoverIcon text="View original project" href={this.reference}>
+                                            <SvgIcon>
+                                                <path
+                                                    d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm0 11.701c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701zm6 0c0 2.857-1.869 4.779-4.5 5.299l-.498-1.063c1.219-.459 2.001-1.822 2.001-2.929h-2.003v-5.008h5v3.701z"/>
+                                            </SvgIcon>
+                                        </HoverIcon>
                                     </Grid>
                                 </Grid>
                             </Grid>

--- a/src/components/service/standardComponents/HoverIcon.js
+++ b/src/components/service/standardComponents/HoverIcon.js
@@ -67,6 +67,7 @@ HoverIcon.propTypes = {
 };
 
 HoverIcon.defaultProps = {
+    text: null,
     fontFamily: "Muli",
     fontSize: 14,
     textColor: "white",

--- a/src/components/service/standardComponents/HoverIcon.js
+++ b/src/components/service/standardComponents/HoverIcon.js
@@ -1,0 +1,75 @@
+import React from "react";
+import Typography from "@material-ui/core/Typography";
+import { Tooltip, IconButton } from "@material-ui/core";
+import PropTypes from "prop-types";
+import { blue, grey } from "@material-ui/core/colors";
+
+export default class HoverIcon extends React.Component{
+    constructor(props){
+        super(props);
+        this.state={
+            hover: false,
+        };
+        this.renderIconButton = this.renderIconButton.bind(this);
+    }
+
+    renderIconButton(){
+        let {children} = this.props;
+        return(
+            <IconButton
+                onMouseEnter={function () {
+                    this.setState({hover: true})
+                }.bind(this)}
+                onMouseLeave={function () {
+                    this.setState({hover: false})
+                }.bind(this)}
+                style={this.state.hover ?
+                    {color: this.props.onColor} : {color: this.props.offColor}}
+                target="_blank"
+                href={this.props.href}
+            >
+                {children}
+            </IconButton>
+        )
+    }
+
+    render(){
+        return(
+            this.props.text ?
+                <Tooltip
+                    title={
+                        <Typography
+                            style={{
+                                fontFamily: this.props.fontFamily,
+                                fontSize: this.props.fontSize,
+                                color: this.props.textColor
+                            }}>
+                            {this.props.text}
+                        </Typography>
+                    }>
+                    {this.renderIconButton()}
+                </Tooltip>
+                :
+                this.renderIconButton()
+        )
+    }
+
+}
+
+HoverIcon.propTypes = {
+    text: PropTypes.string,
+    textColor: PropTypes.PropTypes.string,
+    fontFamily: PropTypes.string,
+    fontSize: PropTypes.number,
+    href: PropTypes.string,
+    onColor: PropTypes.PropTypes.string,
+    offColor: PropTypes.PropTypes.string,
+};
+
+HoverIcon.defaultProps = {
+    fontFamily: "Muli",
+    fontSize: 14,
+    textColor: "white",
+    onColor: blue[500],
+    offColor: grey[600],
+};

--- a/src/components/service/standardComponents/HoverIcon.js
+++ b/src/components/service/standardComponents/HoverIcon.js
@@ -58,12 +58,12 @@ export default class HoverIcon extends React.Component{
 
 HoverIcon.propTypes = {
     text: PropTypes.string,
-    textColor: PropTypes.PropTypes.string,
+    textColor: PropTypes.string,
     fontFamily: PropTypes.string,
     fontSize: PropTypes.number,
     href: PropTypes.string,
-    onColor: PropTypes.PropTypes.string,
-    offColor: PropTypes.PropTypes.string,
+    onColor: PropTypes.string,
+    offColor: PropTypes.string,
 };
 
 HoverIcon.defaultProps = {

--- a/src/components/service/standardComponents/README.md
+++ b/src/components/service/standardComponents/README.md
@@ -1,17 +1,66 @@
 # SingularityNET Standard UI Components
 
-Here's the documentation for SNET's standard components:
+This is the documentation for the official [Material UI](https://material-ui.com/) based standard components for SingularityNET services:
 
 Summary:
+- [Hover Icon](#hover-icon);
 - [Image Upload Component](#image-upload-component);
 
+___
+
+## Hover Icon
+
+> Maintainer: Ramon Durães | http://github.com/ramongduraes | ramon@singularitynet.io
+
+### Functionality
+
+This component is a wrapper for Material UI's icons that turns them into hyperlink buttons. They will change color and display an optional tooltip (`text`) when hovered upon and open the referenced URL (`href`) on another tab upon clicking. The suggested use is to wrap this component around an icon of choice and set its `href` and `text` properties. Other optional parameters are described and an example usage is given in the Parameters and Example Usage sections below, respectively.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| href | string | - | The URL to which the user will be redirected upon clicking the button. |
+| text | string | `null` | Tooltip text shown when the icon is focused. Will not render a Tooltip if not given. |
+| textColor | string | "white" | Tooltip text color. |
+| fontFamily | string | "Muli" | Tooltip text font family. |
+| fontSize | number | "14" | Tooltip text font size. |
+| onColor | string | blue[500] | Icon's active color (onHover). |
+| offColor | string | grey[600] | Icon's inactive color. |
+
+### Example Usage
+
+Below are two example usages of the component, one using Material UI's custom SvgIcon and another using its standard Info icon.
+ 
+```javascript
+import React from 'react';
+import HoverIcon from "./standardComponents/HoverIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
+import InfoIcon from "@material-ui/icons/Info";
+
+export default class App extends Component {    
+    render() {
+        return (
+            <div>
+                <HoverIcon text="View code on Github" href="https://github.com/singnet/snet-dapp/blob/master/src/components/service/standardComponents/HoverIcon.js">
+                    <SvgIcon>
+                        <path // Github Icon
+                            d="M12.007 0C6.12 0 1.1 4.27.157 10.08c-.944 5.813 2.468 11.45 8.054 13.312.19.064.397.033.555-.084.16-.117.25-.304.244-.5v-2.042c-3.33.735-4.037-1.56-4.037-1.56-.22-.726-.694-1.35-1.334-1.756-1.096-.75.074-.735.074-.735.773.103 1.454.557 1.846 1.23.694 1.21 2.23 1.638 3.45.96.056-.61.327-1.178.766-1.605-2.67-.3-5.462-1.335-5.462-6.002-.02-1.193.42-2.35 1.23-3.226-.327-1.015-.27-2.116.166-3.09 0 0 1.006-.33 3.3 1.23 1.966-.538 4.04-.538 6.003 0 2.295-1.5 3.3-1.23 3.3-1.23.445 1.006.49 2.144.12 3.18.81.877 1.25 2.033 1.23 3.226 0 4.607-2.805 5.627-5.476 5.927.578.583.88 1.386.825 2.206v3.29c-.005.2.092.393.26.507.164.115.377.14.565.063 5.568-1.88 8.956-7.514 8.007-13.313C22.892 4.267 17.884.007 12.008 0z"/>
+                    </SvgIcon>
+                </HoverIcon>
+                <HoverIcon text="Material UI" href="https://material-ui.com/">
+                    <InfoIcon/>
+                </HoverIcon>
+            </div>
+        );
+    }
+}
+```
 ___
 
 ## Image Upload Component
 
 > Maintainer: Ramon Durães | http://github.com/ramongduraes | ramon@singularitynet.io
-
-This is the documentation for the official [Material UI](https://material-ui.com/) based image upload component for SingularityNET services.
 
 ### General Functionality
 


### PR DESCRIPTION
Following @Vivek205 's suggestion on PR #236 , here's the code for a HoverIcon component that wraps material UI's Icons and turns them into hyperlinks. Below are three examples of the component side-by-side (the screen was captured when the pointer was over the middle button, displaying its Tooltip text and changing its color).

![Screenshot from 2019-04-18 15-01-44](https://user-images.githubusercontent.com/10756287/56381347-f7413c80-61ea-11e9-8f34-1ba0a0deafe4.png)

The documentation for the code was added to standard component's README file and I have already added the component to my services.