### PR TITLE
Convert object to JSON in default service component

### DIFF
--- a/src/components/service/DefaultService.js
+++ b/src/components/service/DefaultService.js
@@ -47,7 +47,7 @@ export default class DefaultService extends React.Component {
                     return
                 }
 
-                this.state.response = nextProps.response || nextProps.responseObject
+                this.state.response = JSON.stringify(nextProps.response || nextProps.responseObject)
             }
         }
     }


### PR DESCRIPTION
DefaultService handler throws an exception if the response is an object. Fixed this by converting to a JSON string